### PR TITLE
zope plugin interface was removed in v2.0.0

### DIFF
--- a/certbot_dns_metaname/__init__.py
+++ b/certbot_dns_metaname/__init__.py
@@ -21,7 +21,6 @@ Metaname <support@metaname.nz> 2021-05-06
 import json
 
 import requests
-import zope.interface
 
 from certbot import errors
 from certbot import interfaces
@@ -86,8 +85,6 @@ class MetanameApiClient:
 ## Certbot plugin implementation
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """
     Certbot DNS authenticator using the Metaname DNS API

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="certbot-dns-metaname",
-    version="0.0.2",
+    version="0.0.3",
     description="Certbot DNS plugin for the Metaname API",
     url="https://github.com/metaname/certbot-dns-metaname",
     author="Metaname",
@@ -18,7 +18,7 @@ setup(
     ],
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["certbot", "zope.interface", "requests"],
+    install_requires=["certbot", "requests"],
     entry_points={
         "certbot.plugins": ["dns-metaname = certbot_dns_metaname:Authenticator"]
     },


### PR DESCRIPTION
See https://community.letsencrypt.org/t/certbot-2-0-0-release/188240

> The zope based interfaces in certbot.interfaces have been removed in favor of the abc based interfaces found in the same module.

You cannot include the metaname plugin in the latest certbot versions without removing this dependency.